### PR TITLE
Fix Relative Links in Example Files

### DIFF
--- a/examples/publish.php
+++ b/examples/publish.php
@@ -1,6 +1,6 @@
 <?php
 
-require("../vendor/autoload.php");
+require dirname(__FILE__)."/../vendor/autoload.php";
 
 $host = "iot.eclipse.org";
 $port = 1883;

--- a/examples/subscribe.php
+++ b/examples/subscribe.php
@@ -1,6 +1,6 @@
 <?php
 
-require("../vendor/autoload.php");
+require dirname(__FILE__)."/../vendor/autoload.php";
 
 /**
  * An example callback function that is not inline.


### PR DESCRIPTION
Fixes the relative links in the example files so they do not have to be run from the example directory.